### PR TITLE
Fix error when serializing empty blobs/strings

### DIFF
--- a/Serializer.class.nut
+++ b/Serializer.class.nut
@@ -124,9 +124,20 @@ class Serializer {
             case "string":
                 return _write(b, 's', obj);
             case "table":
+                local sorted = array(obj.len());
+                local i = 0;
+                foreach ( k,v in obj ) {
+                    sorted[i++] = [k,v];
+                }
+                sorted.sort( @( first, second ) first[0] <=> second[0] );
+                _write(b, 't', obj.len());
+                foreach ( v in sorted ) {
+                    _serialize(b, v[0]);
+                    _serialize(b, v[1]);
+                }
+                return;
             case "array":
-                local t = (typeof obj == "table") ? 't' : 'a';
-                _write(b, t, obj.len());
+                _write(b, 'a', obj.len());
                 foreach ( k,v in obj ) {
                     _serialize(b, k);
                     _serialize(b, v);
@@ -160,7 +171,7 @@ class Serializer {
             b.writen(payloadlen >> 8 & 0xFF, 'b');
             b.writen(payloadlen & 0xFF, 'b');
         }
-        if (typeof payload == "string" || typeof payload == "blob") {
+		if (typeof payload == "string" || typeof payload == "blob") {
             if (payload.len() > 0) {
                 foreach (ch in payload) {
                     b.writen(ch, 'b');

--- a/Serializer.class.nut
+++ b/Serializer.class.nut
@@ -3,7 +3,7 @@
 // http://opensource.org/licenses/MIT
 
 class Serializer {
-    static version = [1,0,0];
+    static version = [1,1,0];
 
     // Serialize a variable of any type into a blob
     static function serialize (obj, prefix = null) {
@@ -161,8 +161,10 @@ class Serializer {
             b.writen(payloadlen & 0xFF, 'b');
         }
         if (typeof payload == "string" || typeof payload == "blob") {
-            foreach (ch in payload) {
-                b.writen(ch, 'b');
+            if (payload.len() > 0) {
+                foreach (ch in payload) {
+                    b.writen(ch, 'b');
+                }
             }
         }
     }


### PR DESCRIPTION
Was receiving an error message when attempting to serialize an empty blob as it's not possible to foreach() iterate over them so added a length check. As this is potentially a functional change, propose a minor version increment.